### PR TITLE
Rework/editor generator for linking

### DIFF
--- a/api/server/app/assets/modelEditor/editor/own_ext/exportModel.js
+++ b/api/server/app/assets/modelEditor/editor/own_ext/exportModel.js
@@ -53,21 +53,17 @@ var modelExporter = (function modelExporter () {
                 attributes: {}
             };
 
-            if(ele.attributes.hasOwnProperty('mClassAttributes')) {
-                ele.attributes.mClassAttributes.forEach(function (attr) {
-
-                    var attrInfo = ele.attributes.mClassAttributeInfo.find(function(info) {
-                        return info.name === attr.type;
-                    });
-                    var value = _getAttributeValue(attr.value, attrInfo.type);
-                    if (element.attributes.hasOwnProperty(attr.type)) {
-                        element.attributes[attr.type].push(value);
-                    } else {
-                        element.attributes[attr.type] = [value];
+            var attrs = ele.attributes.attrs;
+            for(var key in attrs) {
+                if(_.include(key, "text")) {
+                    var attrName = ele.attributes.mClassAttributeInfo.find(element => element.id === attrs[key].id);
+                    if(attrName !== undefined) {
+                        element.attributes[attrName.name] = attrs[key].text;
                     }
-                });
+                }
             }
 
+            // add all attributes that have no value
             ele.attributes.mClassAttributeInfo.forEach(function(info) {
                 if(!element.attributes.hasOwnProperty(info.name)) {
                     element.attributes[info.name] = [];

--- a/api/server/app/de/htwg/zeta/server/generator/generators/diagram/StencilGenerator.scala
+++ b/api/server/app/de/htwg/zeta/server/generator/generators/diagram/StencilGenerator.scala
@@ -2,9 +2,11 @@ package de.htwg.zeta.server.generator.generators.diagram
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-
 import de.htwg.zeta.server.generator.model.diagram.Diagram
 import de.htwg.zeta.server.generator.model.diagram.node.Node
+
+import scala.util.Try
+import scala.util.Success
 
 /**
  * The StencilGenerator object, responsible for the generation of the String for stencil.js
@@ -69,13 +71,20 @@ object StencilGenerator {
           |  mClassAttributeInfo: [${
           node.mcoreElement.attributes.map(
             attr =>
-              s"""{ name: '${attr.name}', type: '${attr.`type`}'}"""
+              s"""{ name: '${attr.name}', type: '${attr.`type`}' ${textUUID(node, attr.name)}}"""
           ).mkString(",")
         }]
           |});
           |""".stripMargin
       }
     }.mkString
+  }
+
+  private def textUUID(node: Node, name: String): String = {
+    Try(node.shape.get.vars.filter{case (attribute, _) => attribute.name == name}.head) match {
+      case Success(i) => s""", id: '${i._2.id}'"""
+      case _ => ""
+    }
   }
 
   def generateGroupsToStencilMapping(mapping: mutable.HashMap[String, ListBuffer[Node]]): String = {

--- a/api/server/app/de/htwg/zeta/server/generator/generators/shape/GeneratorInspectorDefinition.scala
+++ b/api/server/app/de/htwg/zeta/server/generator/generators/shape/GeneratorInspectorDefinition.scala
@@ -17,8 +17,12 @@ import de.htwg.zeta.server.generator.model.style.HasStyle
 object GeneratorInspectorDefinition {
   val attrCounterMap: mutable.HashMap[String, Int] = mutable.HashMap()
 
-  /**
-   * generates the inspector definition, with input definitions for the JointJS Shapes
+  /** generates the inspector definition, with input definitions for the JointJS Shapes
+   *  @param attrs additional attributes
+   *  @param nodes all nodes
+   *  @param packageName mostly zeta
+   *  @param shapes all shapes
+   *  @return returns generated File as String
    */
   def generate(
     shapes: Iterable[Shape],
@@ -34,7 +38,7 @@ object GeneratorInspectorDefinition {
       |""".stripMargin
   }
 
-  def generateDefinition(
+  private def generateDefinition(
     shape: Shape,
     packageName: String,
     attrs: mutable.HashMap[String, mutable.HashMap[GeometricModel, String]],
@@ -43,7 +47,6 @@ object GeneratorInspectorDefinition {
     var boundWidth = 0
     var boundHeight = 0
     val node = nodes.find(n => n.shape.get.referencedShape.name == shape.name)
-
 
     boundWidth = GeneratorShapeDefinition.calculateWidth(shape)
     boundHeight = GeneratorShapeDefinition.calculateHeight(shape)
@@ -60,8 +63,7 @@ object GeneratorInspectorDefinition {
             getRightAttributes(k, atts(k), boundWidth, boundHeight)
           }).mkString(",")
         }
-          |    },
-          |    ${if (node.isDefined && node.get.mcoreElement.attributes.nonEmpty) generateMClassAttributeInputs(node.get) else ""}
+          |    }
           |  }, CommonInspectorInputs),
           |  groups: CommonInspectorGroups
           |},
@@ -167,8 +169,13 @@ object GeneratorInspectorDefinition {
     s"""
       |'text${if (hasStyle(shape)) "." + shapeClass}' : inp({
       |  text: {
-      |    group: 'Text',
+      |    type: 'list',
+      |    item: {
+      |      type: 'text'
+      |    },
+      |    group: 'Text ${shape.id}',
       |    index: 1
+      |
       |  },
       |  x: {
       |    group: 'Text Geometry ${attrCounterMap(shape.getClass.getSimpleName)}',
@@ -520,34 +527,5 @@ object GeneratorInspectorDefinition {
       case s: HasStyle if s.style.isDefined => true
       case _ => false
     }
-  }
-
-  private def generateMClassAttributeInputs(node: Node): String = {
-    val attributeNames = node.mcoreElement.attributes.map(a => "'" + a.name + "'")
-    s"""
-      |mClassAttributes: {
-      |  type: 'list',
-      |  group: 'data',
-      |  item: {
-      |    type : 'object',
-      |    label : 'Custom Atributes',
-      |    properties : {
-      |      type : {
-      |        type : 'select',
-      |        label : 'Type',
-      |        options : [
-      |          ${attributeNames.mkString(",")}
-      |        ],
-      |        defaultValue : ${attributeNames.toList.head},
-      |        index : 1
-      |      },
-      |      value : {
-      |        type : 'text',
-      |        label: 'Value'
-      |      }
-      |    }
-      |  }
-      |}
-      |""".stripMargin
   }
 }

--- a/api/server/app/de/htwg/zeta/server/generator/generators/shape/GeneratorShapeAndInlineStyle.scala
+++ b/api/server/app/de/htwg/zeta/server/generator/generators/shape/GeneratorShapeAndInlineStyle.scala
@@ -126,7 +126,9 @@ object GeneratorShapeAndInlineStyle {
       """
       """
     if (shape.style.isDefined) {
-      ret += """style['text.""" + shapeClass + """'] = getStyle('""" + shape.style.get.name + """').text;"""
+      ret += s"""style['text.$shapeClass'] = getStyle('${shape.style.get.name}').text;\n"""
+      // quickfix for inspector font-size bug
+      ret += s"""style['.$shapeClass'] = getStyle('${shape.style.get.name}').text;\n"""
     }
     ret
   }

--- a/api/server/app/de/htwg/zeta/server/generator/generators/shape/GeneratorShapeDefinition.scala
+++ b/api/server/app/de/htwg/zeta/server/generator/generators/shape/GeneratorShapeDefinition.scala
@@ -345,7 +345,7 @@ object GeneratorShapeDefinition {
     s"""
       |'width': ${shape.size_width},
       |'height': ${shape.size_height},
-      |text: ${shape.textBody} // Is overwritten in stencil, but needed here for scaling
+      |text: [${shape.textBody}] // Is overwritten in stencil, but needed here for scaling
       |""".stripMargin
   }
 

--- a/api/server/app/de/htwg/zeta/server/generator/generators/shape/GeneratorShapeDefinition.scala
+++ b/api/server/app/de/htwg/zeta/server/generator/generators/shape/GeneratorShapeDefinition.scala
@@ -343,6 +343,7 @@ object GeneratorShapeDefinition {
 
   protected def getAttributes(shape: Text, parentClass: String): String = {
     s"""
+      |${generatePosition(shape)}
       |'id' : '${shape.id}',
       |'width': ${shape.size_width},
       |'height': ${shape.size_height},

--- a/api/server/app/de/htwg/zeta/server/generator/generators/shape/GeneratorShapeDefinition.scala
+++ b/api/server/app/de/htwg/zeta/server/generator/generators/shape/GeneratorShapeDefinition.scala
@@ -343,6 +343,7 @@ object GeneratorShapeDefinition {
 
   protected def getAttributes(shape: Text, parentClass: String): String = {
     s"""
+      |'id' : '${shape.id}',
       |'width': ${shape.size_width},
       |'height': ${shape.size_height},
       |text: [${shape.textBody}] // Is overwritten in stencil, but needed here for scaling

--- a/api/server/app/de/htwg/zeta/server/generator/generators/style/StyleGenerator.scala
+++ b/api/server/app/de/htwg/zeta/server/generator/generators/style/StyleGenerator.scala
@@ -234,7 +234,7 @@ text: {
             |""".stripMargin
         case _ =>
           s"""
-            |'${value.getRGBValue}',
+            |stroke: '${value.getRGBValue}',
             |${processLineWidth(s.line_width)},
             |${processLineStyle(s.line_style)}
           """.stripMargin


### PR DESCRIPTION
Removed "custom attributes" from inspector. Editor reads attributes from text elements. Each text element can handle multiple texts now.