### PR TITLE
Zeta 13

### DIFF
--- a/frontend/src/components/zetalayout/metamodel/graphical-editor/components/graphEditor/GraphEditor.vue
+++ b/frontend/src/components/zetalayout/metamodel/graphical-editor/components/graphEditor/GraphEditor.vue
@@ -91,6 +91,9 @@ import {Grid} from "../../layout/grid/Grid";
 import VuejsNodeStyle from "../../uml/nodes/styles/VuejsNodeStyle";
 import axios from "axios"
 import {EventBus} from "../../../../../../eventbus/eventbus";
+import { Attribute } from "../../uml/attributes/Attribute";
+import { Operation } from "../../uml/operations/Operation";
+
 
 License.value = licenseData;
 
@@ -435,7 +438,7 @@ export default {
      * @param name: name of the attribute to add.
      */
     addAttributeToNode(node, name) {
-      node.attributes = node.attributes.concat({name: name});
+      node.attributes = node.attributes.concat(new Attribute({name: name}));
     },
 
     /**
@@ -458,7 +461,10 @@ export default {
      * @param name: name of the operation to add.
      */
     addOperationToNode(node, name) {
-      node.methods = node.methods.concat({name: name});
+      node.methods = node.methods.concat(new Operation({
+        name: name,
+        returnType: "String",
+        }));
     },
 
     /**
@@ -481,7 +487,7 @@ export default {
      * @param name: name of the attribute to add.
      */
     addAttributeToEdge(edge, name) {
-      edge.attributes = edge.attributes.concat({name: name});
+      edge.attributes = edge.attributes.concat(new Attribute({name: name}));
     },
 
     /**
@@ -504,7 +510,11 @@ export default {
      * @param name: name of the operation to add.
      */
     addOperationToEdge(edge, name) {
-      edge.operations = edge.operations.concat({name: name});
+      edge.operations = edge.operations.concat(new Operation({
+        name: name,
+        returnType: "String"
+        })
+      );
     },
 
     /**

--- a/frontend/src/components/zetalayout/metamodel/graphical-editor/components/graphEditor/GraphEditorUtils.js
+++ b/frontend/src/components/zetalayout/metamodel/graphical-editor/components/graphEditor/GraphEditorUtils.js
@@ -119,10 +119,10 @@ export function saveGraph(graphComponent, loadedMetaModel, metamodelID) {
             exportedMetaModel.getMessages().forEach(message => {
                 errorMessage += message + '\n';
             });
-            showExportFailure(errorMessage);
+            EventBus.$emit('errorMessage', "Failed to save concept: " + errorMessage );
         }
     } else {
-        showSnackbar("No loaded meta model found");
+        EventBus.$emit('errorMessage', "No loaded meta model found.");
     }
 }
 

--- a/frontend/src/components/zetalayout/metamodel/graphical-editor/export/Graph.js
+++ b/frontend/src/components/zetalayout/metamodel/graphical-editor/export/Graph.js
@@ -50,6 +50,9 @@ export default (function () {
       Checks whether the element is abstract.
      */
     Graph.prototype.isAbstract = function (node) {
+        if(node && node.tag && !node.tag.abstractness ) {
+            return false;
+        }
         return node.tag.abstractness;
     };
 


### PR DESCRIPTION
- Persistente Speicherung des Metamodells bei dem Concept-Editor
- Die Attribute sowie die Operationen werden jetzt korrekt als solche Objekte instanziiert und im Code verwendet
- Das gilt sowohl für Knoten und Kanten