### PR TITLE
Cleanup ActorSystem in tests to fix CI

### DIFF
--- a/api/persistence/src/test/scala/de/htwg/zeta/persistence/ActorCacheRepositorySpec.scala
+++ b/api/persistence/src/test/scala/de/htwg/zeta/persistence/ActorCacheRepositorySpec.scala
@@ -41,15 +41,21 @@ import de.htwg.zeta.persistence.transient.TransientPasswordInfoRepository
 import de.htwg.zeta.persistence.transient.TransientSettingsRepository
 import de.htwg.zeta.persistence.transient.TransientTimedTaskRepository
 import de.htwg.zeta.persistence.transient.TransientUserRepository
+import org.scalatest.BeforeAndAfterAll
+import scala.concurrent.Await
 
 /**
  * ActorCacheMicroServiceTest.
  */
-class ActorCacheRepositorySpec extends RepositoryBehavior {
+class ActorCacheRepositorySpec extends RepositoryBehavior with BeforeAndAfterAll {
 
   val system = ActorSystem()
   val cacheDuration = Duration(1, TimeUnit.MINUTES)
   val timeout: Timeout = Duration(1, TimeUnit.MINUTES)
+
+  override def afterAll(): Unit = {
+    Await.result(system.terminate(), Duration.Inf)
+  }
 
   "ActorCacheRepository" should behave like repositoryBehavior(
     new ActorCacheAccessAuthorisationRepository(new TransientAccessAuthorisationRepository, system, 3, cacheDuration, timeout),

--- a/api/server/test/de/htwg/zeta/server/actor/TransientTokenCacheActorSpec.scala
+++ b/api/server/test/de/htwg/zeta/server/actor/TransientTokenCacheActorSpec.scala
@@ -10,17 +10,22 @@ import scala.util.Success
 import akka.actor.ActorSystem
 import akka.util.Timeout
 import de.htwg.zeta.server.model.TokenCache
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 
-class TransientTokenCacheActorSpec extends AnyFlatSpec with Matchers {
+class TransientTokenCacheActorSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
   val system: ActorSystem = ActorSystem()
-  val timeout: Timeout = Duration(3, TimeUnit.MINUTES)
+  val timeout: Timeout = Duration(1, TimeUnit.MINUTES)
   var createActor: TokenCache = new TokenCacheActor(system,timeout)
   var uid : UUID = UUID.randomUUID()
   var userToken : Option[UUID] = None
+
+  override def afterAll(): Unit = {
+    Await.result(system.terminate(), Duration.Inf)
+  }
 
   "ActorTokenCache" should "create instances" in {
     createActor.getClass shouldBe classOf[TokenCacheActor]


### PR DESCRIPTION
Usage of `ActorSystem` in multiple tests caused a blocking of the default address used by the `ActorSystem`. Therefore the TCP binding failed after an `ActorSystem` was already initialized.
Can't explain why this occurred out of the blue. The only thing which could have triggered this behavior is an update of the Ubuntu version which the Github runner is using (`20.04.2 20210405.1` to `20.04.2 20210412.1`).