### PR TITLE
Remove unused contextButton Code from ModelEditor

### DIFF
--- a/frontend/src/components/zetalayout/model/model-editor/components/graphEditor/GraphEditor.vue
+++ b/frontend/src/components/zetalayout/model/model-editor/components/graphEditor/GraphEditor.vue
@@ -219,8 +219,6 @@ export default {
      */
     getInputMode(graphComponent) {
       const mode = getDefaultGraphEditorInputMode();
-      // Turning off interactive node resizing
-      mode.showHandleItems = GraphItemTypes.ALL & ~GraphItemTypes.NODE
       // Add buttons that appear above a selected node for the creation of a new edge
       const umlContextButtonsInputMode = new ModelContextButtonsInputMode();
       umlContextButtonsInputMode.priority = mode.clickInputMode.priority - 1;

--- a/frontend/src/components/zetalayout/model/model-editor/model/utils/ButtonVisualCreator.js
+++ b/frontend/src/components/zetalayout/model/model-editor/model/utils/ButtonVisualCreator.js
@@ -157,36 +157,9 @@ export default class ButtonVisualCreator extends BaseClass(IVisualCreator) {
         // update the container layout
         SvgVisual.setTranslate(svgElement, topRight.x, topRight.y)
 
-        // maybe update the toggle buttons
-        const interfaceButton = svgElement.childNodes[svgElement.childNodes.length - 2]
-        const abstractButton = svgElement.childNodes[svgElement.childNodes.length - 1]
-        if (!interfaceButton || !abstractButton) {
-            this.createVisual(ctx)
-        }
-
         if (cache.width !== layout.width || cache.height !== layout.height) {
-            SvgVisual.setTranslate(interfaceButton, layout.x - topRight.x, layout.y - topRight.y - 25)
-            SvgVisual.setTranslate(abstractButton, layout.x - topRight.x + 25, layout.y - topRight.y - 25)
             cache.width = layout.width
             cache.height = layout.height
-        }
-
-        // update the button state if they have changed
-        if (cache.interfaceToggle !== this.node.tag.stereotype) {
-            interfaceButton.setAttribute(
-                'class',
-                this.node.style.model.stereotype.length > 0
-                    ? 'interface-toggle toggled'
-                    : 'interface-toggle'
-            )
-            cache.interfaceToggle = this.node.style.model.stereotype
-        }
-        if (cache.constraintToggle !== this.node.tag.constraint) {
-            abstractButton.setAttribute(
-                'class',
-                this.node.tag.constraint.length > 0 ? 'abstract-toggle toggled' : 'abstract-toggle'
-            )
-            cache.constraintToggle = this.node.tag.constraint
         }
 
         return oldVisual
@@ -213,33 +186,6 @@ export default class ButtonVisualCreator extends BaseClass(IVisualCreator) {
             ) {
                 return ButtonVisualCreator.edgeCreationButtons[i]
             }
-        }
-        return null
-    }
-
-    /**
-     * Helper method to get the context button at the given location.
-     * @param {INode} node The node who should be checked for a button.
-     * @param {IPoint} location The world location to check for a button.
-     * @returns {string|object} The context button at the given or null.
-     */
-    static getContextButtonAt(node, location) {
-        const layout = node.layout
-        if (
-            location.x >= layout.x &&
-            location.x <= layout.x + 20 &&
-            location.y <= layout.y - 5 &&
-            location.y >= layout.y - 25
-        ) {
-            return 'interface'
-        }
-        if (
-            location.x >= layout.x + 25 &&
-            location.x <= layout.x + 45 &&
-            location.y <= layout.y - 5 &&
-            location.y >= layout.y - 25
-        ) {
-            return 'abstract'
         }
         return null
     }
@@ -330,7 +276,6 @@ class ButtonIconRenderer {
         textElement.textContent = text
         container.appendChild(background)
         container.appendChild(textElement)
-        container.setAttribute('class', text === 'I' ? 'interface-toggle' : 'abstract-toggle')
         return container
     }
 }

--- a/frontend/src/components/zetalayout/model/model-editor/model/utils/ModelContextButtonsInputMode.js
+++ b/frontend/src/components/zetalayout/model/model-editor/model/utils/ModelContextButtonsInputMode.js
@@ -30,7 +30,6 @@ export default class ModelContextButtonsInputMode extends InputModeBase {
 
         // initializes listener functions in order to install/uninstall them
         this.onCurrentItemChangedListener = () => this.onCurrentItemChanged()
-        this.onCanvasClickedListener = (sender, evt) => this.onCanvasClicked(evt.location)
         this.onNodeRemovedListener = (sender, evt) => this.onNodeRemoved(evt.item)
         this.startEdgeCreationListener = (sender, evt) => this.startEdgeCreation(evt.location)
 
@@ -57,7 +56,6 @@ export default class ModelContextButtonsInputMode extends InputModeBase {
         graphComponent.addMouseClickListener(this.startEdgeCreationListener)
         graphComponent.addTouchMoveListener(this.startEdgeCreationListener)
         graphComponent.addTouchDownListener(this.startEdgeCreationListener)
-        graphComponent.inputMode.addCanvasClickedListener(this.onCanvasClickedListener)
         graphComponent.graph.addNodeRemovedListener(this.onNodeRemovedListener)
     }
 
@@ -161,38 +159,6 @@ export default class ModelContextButtonsInputMode extends InputModeBase {
     }
 
     /**
-     * Check whether a context button has been clicked.
-     * @param {Point} location
-     */
-    onCanvasClicked(location) {
-        if (this.active && this.canRequestMutex()) {
-            const graphComponent = this.inputModeContext.canvasComponent
-            for (let enumerator = this.buttonNodes.getEnumerator(); enumerator.moveNext();) {
-                const buttonNode = enumerator.current
-                const contextButton = ButtonVisualCreator.getContextButtonAt(buttonNode, location)
-                if (contextButton) {
-                    if (contextButton === 'interface') {
-                        const isInterface = buttonNode.style.model.stereotype === 'interface'
-                        buttonNode.style.model.stereotype = isInterface ? '' : 'interface'
-                        buttonNode.style.model.constraint = ''
-                        buttonNode.style.fill = isInterface
-                            ? new SolidColorFill(0x60, 0x7d, 0x8b)
-                            : Fill.SEA_GREEN
-                    } else if (contextButton === 'abstract') {
-                        const isAbstract = buttonNode.style.model.constraint === 'abstract'
-                        buttonNode.style.model.constraint = isAbstract ? '' : 'abstract'
-                        buttonNode.style.model.stereotype = ''
-                        buttonNode.style.fill = isAbstract ? new SolidColorFill(0x60, 0x7d, 0x8b) : Fill.CRIMSON
-                    }
-                    buttonNode.style.model.modify()
-                    graphComponent.invalidate()
-                    graphComponent.inputMode.clickInputMode.preventNextDoubleClick()
-                }
-            }
-        }
-    }
-
-    /**
      * Removed the installed listeners when they are not needed anymore.
      * @param {IInputModeContext} context - The context to remove this mode from. This is the same
      *   instance that has been passed to {@link InputModeBase#install}.
@@ -204,7 +170,6 @@ export default class ModelContextButtonsInputMode extends InputModeBase {
         graphComponent.removeMouseClickListener(this.startEdgeCreationListener)
         graphComponent.removeTouchMoveListener(this.startEdgeCreationListener)
         graphComponent.removeTouchDownListener(this.startEdgeCreationListener)
-        graphComponent.inputMode.removeCanvasClickedListener(this.onCanvasClickedListener)
         graphComponent.graph.removeNodeRemovedListener(this.onNodeRemovedListener)
         this.buttonNodes.clear()
         this.manager.dispose()


### PR DESCRIPTION
Wieder mal ein Kopierfehler, als der komplette ConceptEditor kopiert wurde, um daraus den ModelEditor zu machen.
ContextButtons, die im ConceptEditor für Abstract und Interface verwendet werden, existieren im ModelEditor nicht.
Trotzdem war der Programmcode noch vorhanden und hat beim Resizing Exceptions ausgelöst.