### PR TITLE
Zeta 88

### DIFF
--- a/frontend/src/components/zetalayout/metamodel/graphical-editor/components/graphEditor/GraphEditor.vue
+++ b/frontend/src/components/zetalayout/metamodel/graphical-editor/components/graphEditor/GraphEditor.vue
@@ -90,8 +90,8 @@ import {Grid} from "../../layout/grid/Grid";
 import VuejsNodeStyle from "../../uml/nodes/styles/VuejsNodeStyle";
 import axios from "axios"
 import {EventBus} from "@/eventbus/eventbus";
-import { Attribute } from "../../uml/attributes/Attribute";
-import { Method } from "../../uml/methods/Method";
+import {Attribute} from "../../uml/attributes/Attribute";
+import {Method} from "../../uml/methods/Method";
 
 
 License.value = licenseData;
@@ -179,6 +179,7 @@ export default {
       methods.deleteAttributeFromNode = this.deleteAttributeFromNode;
       methods.deleteOperationFromNode = this.deleteOperationFromNode;
       methods.changeInputMode = this.changeInputMode;
+      methods.getIsEditEnabled = this.getIsEditEnabled;
       const NodeConstructor = Vue.extend(Node);
       //this.$graphComponent.graph.nodeDefaults.size = new Size(60, 40);
       this.$graphComponent.graph.nodeDefaults.style = new VuejsNodeStyle(NodeConstructor, methods, this.$graphComponent.inputMode);
@@ -229,6 +230,7 @@ export default {
       methods.deleteAttributeFromNode = this.deleteAttributeFromNode;
       methods.deleteOperationFromNode = this.deleteOperationFromNode;
       methods.changeInputMode = this.changeInputMode;
+      methods.getIsEditEnabled = this.getIsEditEnabled;
       // Create nodes that can be appended to the graph by the builder
       const graphNodes = nodes.map(node => graph.createNode({
         tag: node,
@@ -405,6 +407,10 @@ export default {
       this.isEditEnabled = editable
     },
 
+    getIsEditEnabled() {
+      return this.isEditEnabled;
+    },
+
     /**
      * Toggles the grid and snapping to the grid.
      * Needs a parameter on which the toggle state of the grid is based on, since the decision
@@ -442,7 +448,9 @@ export default {
      * @param name: name of the attribute to add.
      */
     addAttributeToNode(node, name) {
-      node.attributes = node.attributes.concat(new Attribute({name: name}));
+      if (this.isEditEnabled) {
+        node.attributes = node.attributes.concat(new Attribute({name: name}));
+      }
     },
 
     /**
@@ -455,7 +463,9 @@ export default {
      * @param name: name of the attribute to delete.
      */
     deleteAttributeFromNode(node, name) {
-      node.attributes = node.attributes.filter(attribute => attribute.name !== name);
+      if (this.isEditEnabled) {
+        node.attributes = node.attributes.filter(attribute => attribute.name !== name);
+      }
     },
 
     /**
@@ -465,10 +475,12 @@ export default {
      * @param name: name of the operation to add.
      */
     addOperationToNode(node, name) {
-      node.methods = node.methods.concat(new Method({
-        name: name,
-        returnType: "String",
+      if (this.isEditEnabled) {
+        node.methods = node.methods.concat(new Method({
+          name: name,
+          returnType: "String",
         }));
+      }
     },
 
     /**
@@ -481,7 +493,9 @@ export default {
      * @param name: name of the operation to delete
      */
     deleteOperationFromNode(node, name) {
-      node.methods = node.methods.filter(attribute => attribute.name !== name);
+      if (this.isEditEnabled) {
+        node.methods = node.methods.filter(attribute => attribute.name !== name);
+      }
     },
 
     /**
@@ -515,9 +529,9 @@ export default {
      */
     addOperationToEdge(edge, name) {
       edge.methods = edge.methods.concat(new Method({
-        name: name,
-        returnType: "String"
-        })
+            name: name,
+            returnType: "String"
+          })
       );
     },
 

--- a/frontend/src/components/zetalayout/metamodel/graphical-editor/components/nodes/Node.vue
+++ b/frontend/src/components/zetalayout/metamodel/graphical-editor/components/nodes/Node.vue
@@ -26,7 +26,8 @@
                 <VueInlineTextEditor
                     @change-input-mode="(newInputMode) => methods.changeInputMode(newInputMode)"
                     :inputMode="inputMode"
-                    :value.sync="attribute.name"/>
+                    :value.sync="attribute.name"
+                    :isEditEnabled="methods.getIsEditEnabled()"/>
               </foreignObject>
               <image :x="layout.width - 22"
                      :y="45"
@@ -63,7 +64,8 @@
                 <VueInlineTextEditor
                     @change-input-mode="(newInputMode) => methods.changeInputMode(newInputMode)"
                     :inputMode="inputMode"
-                    :value.sync="method.name"/>
+                    :value.sync="method.name"
+                    :isEditEnabled="methods.getIsEditEnabled()"/>
               </foreignObject>
               <image :x="layout.width - 22"
                      :y="75 + 30 * (attributes_open ? Object.keys(tag.attributes).length : 0)"

--- a/frontend/src/components/zetalayout/metamodel/graphical-editor/components/nodes/VueInlineTextEditor.vue
+++ b/frontend/src/components/zetalayout/metamodel/graphical-editor/components/nodes/VueInlineTextEditor.vue
@@ -25,237 +25,245 @@ https://github.com/causelabs/vue-inline-text-editor
 -->
 
 <template>
-    <div class="inline-editor" :class="classes">
-        <div v-if="editingValue !== null" class="content-field">
-            <input
-                type="text"
-                v-model="editingValue"
-                @change="emitChange"
-                @blur="emitBlur"
-                @keyup.enter="updateValue"
-                @keyup.esc="cancelEdit"
-                greetings
-                :placeholder="placeholder"
-                :required="required"
-                ref="input"
-            >
-        </div>
-        <div  @click.stop="clickHandler" class="value-display" v-if="currentlyEditing == false">
+  <div class="inline-editor" :class="classes">
+    <div v-if="editingValue !== null" class="content-field">
+      <input
+          type="text"
+          v-model="editingValue"
+          @change="emitChange"
+          @blur="emitBlur"
+          @keyup.enter="updateValue"
+          @keyup.esc="cancelEdit"
+          greetings
+          :placeholder="placeholder"
+          :required="required"
+          ref="input"
+      >
+    </div>
+    <div @click.stop="clickHandler" class="value-display" v-if="currentlyEditing == false">
             <span>{{ formattedValue }}
             </span>
-        </div>
     </div>
+  </div>
 </template>
 
 <script>
 
 export default {
-    name: 'VueInlineTextEditor',
-    props: {
-        autofocus: {
-            type: Boolean,
-            default: true
-        },
-        closeOnBlur: {
-            type: Boolean,
-            default: false
-        },
-        disabled: {
-            type: Boolean,
-            default: false
-        },
-        hoverEffects: {
-            type: Boolean,
-            default: false
-        },
-        maxLength: {
-            type: Number,
-            default: null
-        },
-        minLength: {
-            type: Number,
-            default: null
-        },
-        placeholder: {
-            type: String,
-            default: null
-        },
-        required: {
-            type: Boolean,
-            default: false
-        },
-        type: {
-            type: String,
-            default: 'text',
-            validator (value) {
-                return ['text', 'number', 'currency', 'percentage'].indexOf(value) > -1
-            }
-        },
-        inputMode:{
-            required: true
-        },
-        value: {
-            required: true
-        }
+  name: 'VueInlineTextEditor',
+  props: {
+    autofocus: {
+      type: Boolean,
+      default: true
     },
-    data () {
-        return {
-            editingValue: null,
-            internalValue: this.value,
-            currentlyEditing: false,
-            savedInputMode: null
-        }
+    closeOnBlur: {
+      type: Boolean,
+      default: false
     },
-    computed: {
-        classes () {
-            let classNames = []
-            if (this.hoverEffects) {
-                classNames.push('hover-effects')
-            }
-            if (this.editingValue !== null) {
-                classNames.push('editing')
-            }
-            if (this.disabled) {
-                classNames.push('disabled')
-            }
-            classNames.push('type-' + this.type)
-            return classNames.join(' ')
-        },
-
-        formattedValue () {
-            if ((null === this.internalValue) || ('' === this.internalValue)) {
-                return this.placeholder
-            }
-            return this.internalValue
-        }
+    disabled: {
+      type: Boolean,
+      default: false
     },
-    watch: {
-        internalValue (newValue) {
-           // console.log(newValue)
-            this.$emit('update:value', newValue)
-        },
-        selectValue (newValue) {
-            console.log(newValue)
-            this.internalSelectValue = newValue
-        },
-        value (newValue) {
-            console.log(newValue)
-            this.internalValue = newValue
-        },
+    hoverEffects: {
+      type: Boolean,
+      default: false
     },
-    mounted () {
-        // If this field is required, but is empty, open the editor
-        if (this.required) {
-            if ((this.internalValue === '') || (this.internalValue === null)) {
-                this.editingValue = ''
-                this.showSelect = true
-            }
-        }
+    maxLength: {
+      type: Number,
+      default: null
     },
-    methods: {
-        cancelEdit () {
-            this.internalSelectValue = this.originalSelectValue
-            this.closeEditor()
-        },
-        closeEditor () {
-            this.unlockInputMode();
-            this.currentlyEditing = false;
-            this.editingValue = null
-            this.$emit('close')
-            this.originalSelectValue = null
-        },
-        clickHandler(){          
-            this.currentlyEditing = true;
-            this.lockInputMode();
-            this.editValue()
-        },
-        
-        lockInputMode(){
-            this.savedInputMode = this.inputMode 
-            this.$emit('change-input-mode', null);
-        },
-
-        unlockInputMode(){
-            this.$emit('change-input-mode', this.savedInputMode);
-        },
-
-        editValue () {
-            if (this.disabled) {
-                return
-            }
-            if (this.internalValue === null) {
-                // Clicking into an empty editor, set to an empty string
-                this.editingValue = ''
-            } else {
-                this.editingValue = this.internalValue
-            }
-            this.filterValue()
-            this.originalSelectValue = this.internalSelectValue
-            // Set the focus to the input
-            window.setTimeout(() => {
-                this.showSelect = true
-                this.focus()
-            }, 10)
-            this.$emit('open')
-        },
-        emitBlur (e) {
-            this.$emit('blur', e)
-            if (this.closeOnBlur === true) {
-                this.updateValue()
-            }
-        },
-        emitChange (e) {
-            this.$emit('change', e)
-        },
-        filterValue () {
-            if (this.editingValue === null) {
-                return
-            }
-            if (['number', 'currency', 'percentage'].indexOf(this.type) > -1) {
-                this.editingValue = this.editingValue.toString().replace(/[^0-9.]/g, '')
-            }
-        },
-        focus () {
-            try {
-                this.$nextTick(() => {
-                    if (this.$refs && this.$refs.input) {
-                        this.$refs.input.focus()
-                    }
-                })
-            } catch (ignore) {
-                // ignore
-            }
-        },
-        updateValue () {
-            let isChanged = false
-            if (this.internalValue !== this.editingValue) {
-                this.internalValue = this.editingValue
-                isChanged = true
-            }
-            if (isChanged) {
-                this.$nextTick(() => {
-                    this.$emit('update')
-                })
-            }
-            this.closeEditor()
-        },
+    minLength: {
+      type: Number,
+      default: null
+    },
+    placeholder: {
+      type: String,
+      default: null
+    },
+    required: {
+      type: Boolean,
+      default: false
+    },
+    type: {
+      type: String,
+      default: 'text',
+      validator(value) {
+        return ['text', 'number', 'currency', 'percentage'].indexOf(value) > -1
+      }
+    },
+    inputMode: {
+      required: true
+    },
+    value: {
+      required: true
+    },
+    isEditEnabled: {
+      type: Boolean,
+      required: true
     }
+  },
+  data() {
+    return {
+      editingValue: null,
+      internalValue: this.value,
+      currentlyEditing: false,
+      savedInputMode: null
+    }
+  },
+  computed: {
+    classes() {
+      let classNames = []
+      if (this.hoverEffects) {
+        classNames.push('hover-effects')
+      }
+      if (this.editingValue !== null) {
+        classNames.push('editing')
+      }
+      if (this.disabled) {
+        classNames.push('disabled')
+      }
+      classNames.push('type-' + this.type)
+      return classNames.join(' ')
+    },
+
+    formattedValue() {
+      if ((null === this.internalValue) || ('' === this.internalValue)) {
+        return this.placeholder
+      }
+      return this.internalValue
+    }
+  },
+  watch: {
+    internalValue(newValue) {
+      // console.log(newValue)
+      this.$emit('update:value', newValue)
+    },
+    selectValue(newValue) {
+      console.log(newValue)
+      this.internalSelectValue = newValue
+    },
+    value(newValue) {
+      console.log(newValue)
+      this.internalValue = newValue
+    },
+  },
+  mounted() {
+    // If this field is required, but is empty, open the editor
+    if (this.required) {
+      if ((this.internalValue === '') || (this.internalValue === null)) {
+        this.editingValue = ''
+        this.showSelect = true
+      }
+    }
+  },
+  methods: {
+    cancelEdit() {
+      this.internalSelectValue = this.originalSelectValue
+      this.closeEditor()
+    },
+    closeEditor() {
+      this.unlockInputMode();
+      this.currentlyEditing = false;
+      this.editingValue = null
+      this.$emit('close')
+      this.originalSelectValue = null
+    },
+    clickHandler() {
+      if (this.isEditEnabled) {
+        this.currentlyEditing = true;
+        this.lockInputMode();
+        this.editValue()
+      }
+    },
+
+    lockInputMode() {
+      this.savedInputMode = this.inputMode
+      this.$emit('change-input-mode', null);
+    },
+
+    unlockInputMode() {
+      this.$emit('change-input-mode', this.savedInputMode);
+    },
+
+    editValue() {
+      if (this.disabled) {
+        return
+      }
+      if (this.internalValue === null) {
+        // Clicking into an empty editor, set to an empty string
+        this.editingValue = ''
+      } else {
+        this.editingValue = this.internalValue
+      }
+      this.filterValue()
+      this.originalSelectValue = this.internalSelectValue
+      // Set the focus to the input
+      window.setTimeout(() => {
+        this.showSelect = true
+        this.focus()
+      }, 10)
+      this.$emit('open')
+    },
+    emitBlur(e) {
+      this.closeEditor()
+      this.$emit('blur', e)
+      if (this.closeOnBlur === true) {
+        this.updateValue()
+      }
+    },
+    emitChange(e) {
+      this.$emit('change', e)
+    },
+    filterValue() {
+      if (this.editingValue === null) {
+        return
+      }
+      if (['number', 'currency', 'percentage'].indexOf(this.type) > -1) {
+        this.editingValue = this.editingValue.toString().replace(/[^0-9.]/g, '')
+      }
+    },
+    focus() {
+      try {
+        this.$nextTick(() => {
+          if (this.$refs && this.$refs.input) {
+            this.$refs.input.focus()
+          }
+        })
+      } catch (ignore) {
+        // ignore
+      }
+    },
+    updateValue() {
+      let isChanged = false
+      if (this.internalValue !== this.editingValue) {
+        this.internalValue = this.editingValue
+        isChanged = true
+      }
+      if (isChanged) {
+        this.$nextTick(() => {
+          this.$emit('update')
+        })
+      }
+      this.closeEditor()
+    },
+  }
 }
 </script>
 
 <style lang="css" scoped>
 
 
-.inline-editor{
-    display: inline-block;
-    cursor: text;
+.inline-editor {
+  display: inline-block;
+  cursor: text;
 }
 
-.value-display{
-    font-size: 15px;
+.value-display {
+  font-size: 15px;
 }
-.content-field{
-    background-color: white;
-    font-size: 15px;
+
+.content-field {
+  background-color: white;
+  font-size: 15px;
 }
 </style>

--- a/frontend/src/components/zetalayout/model/model-editor/components/graphEditor/GraphEditor.vue
+++ b/frontend/src/components/zetalayout/model/model-editor/components/graphEditor/GraphEditor.vue
@@ -283,6 +283,7 @@ export default {
               })
             }
             if (FirstEdge) {
+              window.currentEdge = FirstEdge.conceptElement.split(".").pop()
               this.registerPortCandidateProvider(graphComponent.graph, target)
             }
           }


### PR DESCRIPTION
- Fix Inline Editing Bugs

- Textfields (Attributes/Operationen) werden nur noch geändert bei "Enter" Taste, 
- Reset der Textfields wird jetzt korrekt durchgeführt (man kann mehrmals Texte ändern)
- Eingaben nur möglich wenn "Toggle" aktiviert ist
- Löschen nur möglich wenn "Toggle" aktiviert ist 